### PR TITLE
Multiple nodes in same app + proper msg.payloads!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+node_modules/*

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 `action` values:
 
 - "C" -> Creates a database
-        * When you create a new database, the node will send as output the name of Database.
+        - When you create a new database, the node will send as output the name of Database.
 - "L" -> Lists databases
 - "D" -> Deletes a database
 
@@ -53,7 +53,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
         { "dbname": "databaseName", "collName": "collectionName", "action": "C" }
 
 - "C" -> create a document
-        * Specify your document by adding a property called `doc` to the configuration JSON, e.g.
+        - Specify your document by adding a property called `doc` to the configuration JSON, e.g.
         
         { "name": 'Lucas', "favoriteFood": "Pizza" }
 
@@ -61,7 +61,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 - "D" -> delete a document
 - "U" -> update a document
 - "Q" -> query a documents
-        * Specify your query by adding a property called `query` to the configuration JSON, e.g.
+        - Specify your query by adding a property called `query` to the configuration JSON, e.g.
         
                 `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`        
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 `action` values:
 
 - "C" -> Creates a database
--- When you create a new database, the node will send as output the name of Database.
+        * When you create a new database, the node will send as output the name of Database.
 - "L" -> Lists databases
 - "D" -> Deletes a database
 
@@ -53,7 +53,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
         { "dbname": "databaseName", "collName": "collectionName", "action": "C" }
 
 - "C" -> create a document
-        - Specify your document by adding a property called `doc` to the configuration JSON, e.g.
+        * Specify your document by adding a property called `doc` to the configuration JSON, e.g.
         
         { "name": 'Lucas', "favoriteFood": "Pizza" }
 
@@ -61,11 +61,9 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 - "D" -> delete a document
 - "U" -> update a document
 - "Q" -> query a documents
-        - Specify your query by adding a property called `query` to the configuration JSON, e.g.
+        * Specify your query by adding a property called `query` to the configuration JSON, e.g.
         
-                `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`
-                
-        - Note: single quotes will be replaced at execution-time with double-quotes
+                `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`        
 
 Results are passed to the next flow in `msg.payload`. If you need to retrieve the orignal query or check the status of the previous operation, you can check the `msg.docdb` object:
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,73 @@
-Node-Red node to connect to Azure DocumentDB
-==============================
+# NodeRed-Azure-DocumentDB
 
-<a href="http://nodered.org" target="_new">Node-RED</a> nodes to talk to Azure DocumentDB.
+Add-on nodes for Node RED (http://nodered.org) to perform various admnistrative and data operations against Azure's CosmosDB (formerly DocumentDB).
 
-Some code of Azure are under MIT License.
+Please note: some code of Azure is under an MIT License.
 
-Install
--------
+## Install
 
 Run the following command in your Node-RED user directory - typically `~/.node-red`
 
         npm install node-red-contrib-azure-documentdb
 
-Usage
------
+## Usage
 
-Azure node. Can be used to work with Azure DocumentDB using 3 nodes:
+Can be used to work with Azure DocumentDB using 3 nodes:
 
- - Supports :
- 
-◦CRUD Database and Collections
-◦Create/List/Update/Delete and Query Documents
+- `Database` -> Manages databases
+- `Collections` -> Manage collections
+- `Documents` -> Data operations against documents: Cread, Read, Update, Delete and Query
+
+Once installed, you'll find the nodes under the `cloud` section.
+
+For each of the nodes, you'll set the `msg.payload` to a configuration JSON that will instruct the node what to do when executed.
+
+### Database Node
+
+`msg.payload` Example:
+
+        { "dbname": "databaseName", "action": "C" };
+
+`action` values:
+
+- "C" -> Creates a database
+-- When you create a new database, the node will send as output the name of Database.
+- "L" -> Lists databases
+- "D" -> Deletes a database
 
 
-##Database Node
-Use `msg.payload` to create, delete and list the Database name.
+### Collections Node
 
-Ex: 'msg.payload' -> {"dbname": "databaseName", "action": "C"};
+`msg.payload` Example:
 
-
-- put "C" to crete a Database
-        - If you create a new database, the node will send as output the name of Database.
-
-- put "L" to list Database
-
-- put "D" to delete a Database
-
-
-##Collections Node
-Use `msg.payload` to create, delete and list the Collection name.
-
-Ex: 'msg.payload' -> {"dbname": "databaseName", "collName": "colletionName", "action": "C"};
+        { "dbname": "databaseName", "collName": "collectionName", "action": "C" };
 
 - put "C" to crete a Collection
 - put "L" to list Collection
 - put "D" to delete a Collection
 
-##Documents Node
-Use `msg.payload` to work with documents in DocumentDB
+### Documents Node
 
-Ex: 'msg.payload' -> {"dbname": "databaseName", "collName": "colletionName", "action": "C", "doc": "*"};
+`msg.payload` Example:
 
-- put "C" to crete a Document
-        - * Doc as JSON -> {"name": "Lucas", "lastname": "Humenhuk"}
-- put "L" to list Documents
-- put "D" to delete a Document
-- put "U" to update a Document
-- put "Q" to query a document
-        - To query a document. Ex: 'SELECT VALUE r.address FROM root r WHERE r.firstname = "Lucas"'
+        { "dbname": "databaseName", "collName": "collectionName", "action": "C" }
 
+- "C" -> create a document
+-- Specify your document by adding a property called `doc` to the configuration JSON, e.g. `{ "name": 'Lucas', "favoriteFood": "Pizza" }`
+- "L" -> list documents
+- "D" -> delete a document
+- "U" -> update a document
+- "Q" -> query a documents
+-- Specify your query by adding a property called `query` to the configuration JSON, e.g. `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`
+-- Note: single quotes will be replaced at execution-time with double-quotes
 
+Results are passed to the next flow in `msg.payload`. If you need to retrieve the orignal query or check the status of the previous operation, you can check the `msg.docdb` object:
 
+- `msg.docdb.query` -> Original executed query
+- `msg.docdb.result` -> `OK` if the operation succeeded; `Error` if the operation failed
 
------
+## References
 
-Read more about Azure DocumentDB on <a href="https://azure.microsoft.com/pt-br/documentation/services/documentdb/">Azure DocumentDB</a>.
+Read more about Azure CosmosDB at https://azure.microsoft.com/pt-br/documentation/services/documentdb/.
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 - "C" -> create a document
         - Specify your document by adding a property called `doc` to the configuration JSON, e.g.
         
-        { "name": 'Lucas', "favoriteFood": "Pizza" }
+        "doc": { "name": 'Lucas', "favoriteFood": "Pizza" }
 
 - "L" -> list documents
 - "D" -> delete a document
@@ -63,7 +63,7 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
 - "Q" -> query a documents
         - Specify your query by adding a property called `query` to the configuration JSON, e.g.
         
-                `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`        
+        "query": "SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'"
 
 Results are passed to the next flow in `msg.payload`. If you need to retrieve the orignal query or check the status of the previous operation, you can check the `msg.docdb` object:
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,19 @@ For each of the nodes, you'll set the `msg.payload` to a configuration JSON that
         { "dbname": "databaseName", "collName": "collectionName", "action": "C" }
 
 - "C" -> create a document
--- Specify your document by adding a property called `doc` to the configuration JSON, e.g. `{ "name": 'Lucas', "favoriteFood": "Pizza" }`
+        - Specify your document by adding a property called `doc` to the configuration JSON, e.g.
+        
+        { "name": 'Lucas', "favoriteFood": "Pizza" }
+
 - "L" -> list documents
 - "D" -> delete a document
 - "U" -> update a document
 - "Q" -> query a documents
--- Specify your query by adding a property called `query` to the configuration JSON, e.g. `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`
--- Note: single quotes will be replaced at execution-time with double-quotes
+        - Specify your query by adding a property called `query` to the configuration JSON, e.g.
+        
+                `SELECT VALUE r.address FROM root r WHERE r.firstname = 'Lucas'`
+                
+        - Note: single quotes will be replaced at execution-time with double-quotes
 
 Results are passed to the next flow in `msg.payload`. If you need to retrieve the orignal query or check the status of the previous operation, you can check the `msg.docdb` object:
 

--- a/azuredocumentdb.js
+++ b/azuredocumentdb.js
@@ -457,71 +457,83 @@ function listDocuments(collLink, callback) {
             setStatus(statusEnum.sending);
             switch (action) {
                 case "C":
-                    node.log('Attempting to create document...');
-                    //node.log(JSON.parse(messageJSON.doc));
+                    node.log('Attempting to create Document...');                    
                     getDocument(messageJSON.doc).then((resolve) => { 
-                       node.log('Document creation completed successfully ' + JSON.stringify(resolve));
+                        node.log('Completed successfully ' + JSON.stringify(resolve));
                         setStatus(statusEnum.sent);
-                        node.send('Document creation completed successfully ' + JSON.stringify(resolve));  
+
+                        msg.docdb = { "query": msg.payload, "result": "OK" };
+                        msg.payload = resolve;
+
+                        node.send(msg);  
                     }).catch((error) => { 
                         setStatus(statusEnum.error);
-                        node.error('Document creation completed with error ' +JSON.stringify(error), msg);
-                       node.log('Document creation completed with error ' +JSON.stringify(error));
+                        node.error('Completed with error ' +JSON.stringify(error), msg);                       
                     });
                     break;
+
                 case "L":
-                    node.log('Attempting to list documents...');
+                    node.log('Attempting to list Documents...');
                     var listNames = [];
                     listDocuments(collectionUrl, function (docs) {
                         setStatus(statusEnum.sent);
-                        if (docs.length == 1) {
-                            node.send(docs[0].id)
-                        } else {
-                            for (var i = 0; i < docs.length; i++) {
-                                listNames.push(docs[i].id);
-                            }
-                            node.send(JSON.stringify(listNames));
-                        }
+
+                        msg.docdb = { "query": msg.payload, "result": "OK" };
+                        msg.payload = docs;
+
+                        node.send(msg);
                     })
                     break;
+
                 case "D":
-                    node.log('Attempting to delete document...');
+                    node.log('Attempting to delete Documents...');
                     deleteDocument(messageJSON.doc).then((resolve) => { 
                         node.log('Delete successfully ' + JSON.stringify(resolve));
                         setStatus(statusEnum.sent);
-                        node.send('Delete successfully ' + JSON.stringify(resolve)); 
+
+                        msg.docdb = { "query": msg.payload, "result": "OK" };
+                        msg.payload = resolve;
+
+                        node.send(msg); 
                     }).catch((error) => { 
                         setStatus(statusEnum.error);
-                        node.error('Document delete failed ' +JSON.stringify(error), msg);
-                        node.log('Delete failed ' +JSON.stringify(error));
-                });
+                        node.error('Delete with error ' +JSON.stringify(error), msg);
+                    });
                     break;
+
                 case "U":
                     node.log('Attempting to update document...');
                     replaceDocument(messageJSON.doc).then((resolve) => { 
                         node.log('Updated successfully ' + JSON.stringify(resolve));
                         setStatus(statusEnum.sent);
-                        node.send('Updated successfully ' + JSON.stringify(resolve)); 
+
+                        msg.docdb = { "query": msg.payload, "result": "OK" };
+                        msg.payload = resolve;
+
+                        node.send(msg);
                     }).catch((error) => { 
                         setStatus(statusEnum.error);
-                        node.error('Updated with error ' +JSON.stringify(error), msg);
-                        node.log('Updated with error ' +JSON.stringify(error));
-                });
+                        node.error('Updated with error ' +JSON.stringify(error) + '\r\n' + JSON.stringify(msg.payload), msg);
+                    });
                     break;
+
                 case "Q":
-                    node.log('Attempting to query for documents...');
+                    node.log('Attempting to query document...');
                     queryDocuments(messageJSON.query).then((resolve) => { 
                         node.log('Query successfully ' + JSON.stringify(resolve));
                         setStatus(statusEnum.sent);
-                        node.send('Query successfully ' + JSON.stringify(resolve)); 
+
+                        msg.docdb = { "query": msg.payload, "result": "OK" };
+                        msg.payload = resolve;
+
+                        node.send(msg); 
                     }).catch((error) => { 
                         setStatus(statusEnum.error);
                         node.error('Query with error ' +JSON.stringify(error), msg);
-                        node.log('Query with error ' +JSON.stringify(error));
-                });
+                    });
                     break;
+
                 default:
-                    node.log('You did not supply an action. Please make sure msg.payload.action is set to C/L/D/U/Q.');
                     node.error('You did not supply an action. Please make sure msg.payload.action is set to C/L/D/U/Q.', msg);
                     setStatus(statusEnum.error);
                     break;


### PR DESCRIPTION
- **Scope Management** - Major changes to better handle JS scope of variables and support multiple instances of the same node in a flow. Before these changes, behavior was often inconsistent in a parallel environment, e.g. if using the DocDB nodes behind HTTP requests. Moved most of the references to `node` and `client` to locally-scoped variables so we don't run into concurrency issues with the globally-scoped versions.
- **`msg.send` preserves original message** - the `Collections` and `Documents` nodes' use of `msg.send` to return the original message and store the result of the operation in `msg.payload`. This enables support for HTTP request/response pairs, as those nodes require that you carry the original `msg` all the way through to the response node.
- **`node.error()` preserves original message** - same as above, but enables Node RED `catch` nodes to be triggered and flow as expected, while preserving the original message context.

Note: I have NOT updated the `Databases` node to align to the above. I don't use it, but may submit a PR later to cover it.
